### PR TITLE
Support inheritance

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,1 @@
+strong: True

--- a/example/bin/main.dart
+++ b/example/bin/main.dart
@@ -7,4 +7,7 @@ void main() {
   ex1.bar = 7;
   ex2.bar = -12;
   print('two nonequal examples will not be equal: ${ex1 == ex2}');
+  print('Both examples print properly:');
+  print(ex1);
+  print(ex2);
 }

--- a/example/bin/main.dart
+++ b/example/bin/main.dart
@@ -1,12 +1,10 @@
 import 'package:example/example.dart';
 
 void main() {
-  var eq1 = new Eq1();
-  var eq2 = new Eq1();
-  print('two eqs without their equals methods implemented will not be '
-      'equal: ${eq1 == eq2}');
-  var eq1Mirror = new Eq1$CompiledMirror(eq1);
-  var eq2Mirror = new Eq1$CompiledMirror(eq2);
-  print('two mirrors can determine that they are equal: '
-      '${eq1Mirror.deepEquals(eq2Mirror)}');
+  var ex1 = new Example()..foo = 'Foo';
+  var ex2 = new Example()..foo = 'Foo';
+  print('two equal examples will be equal: ${ex1 == ex2}');
+  ex1.bar = 7;
+  ex2.bar = -12;
+  print('two nonequal examples will not be equal: ${ex1 == ex2}');
 }

--- a/example/lib/example.compiled_mirrors.dart
+++ b/example/lib/example.compiled_mirrors.dart
@@ -1,18 +1,19 @@
 import 'package:compiled_mirrors/compiled_mirrors.dart';
 import 'example.dart';
 
-class Eq1$CompiledMirror extends CompiledMirror<Eq1> {
+class Example$CompiledMirror extends CompiledMirror<Example> {
   @override
-  final Eq1 instance;
+  final Example instance;
 
   @override
   final Map<Symbol, FieldAccessor> fields;
 
-  Eq1$CompiledMirror(Eq1 instance):
+  Example$CompiledMirror(Example instance):
     this.instance = instance,
     this.fields = {
       #foo: () => instance.foo,
       #bar: () => instance.bar,
+      #hashCode: () => instance.hashCode,
     };
 
 }

--- a/example/lib/example.compiled_mirrors.dart
+++ b/example/lib/example.compiled_mirrors.dart
@@ -11,9 +11,8 @@ class Example$CompiledMirror extends CompiledMirror<Example> {
   Example$CompiledMirror(Example instance):
     this.instance = instance,
     this.fields = {
-      #foo: () => instance.foo,
       #bar: () => instance.bar,
-      #ham: () => instance.ham,
+      #foo: () => instance.foo,
     };
 
 }

--- a/example/lib/example.compiled_mirrors.dart
+++ b/example/lib/example.compiled_mirrors.dart
@@ -13,7 +13,6 @@ class Example$CompiledMirror extends CompiledMirror<Example> {
     this.fields = {
       #foo: () => instance.foo,
       #bar: () => instance.bar,
-      #hashCode: () => instance.hashCode,
     };
 
 }

--- a/example/lib/example.compiled_mirrors.dart
+++ b/example/lib/example.compiled_mirrors.dart
@@ -13,6 +13,7 @@ class Example$CompiledMirror extends CompiledMirror<Example> {
     this.fields = {
       #foo: () => instance.foo,
       #bar: () => instance.bar,
+      #ham: () => instance.ham,
     };
 
 }

--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -3,16 +3,8 @@ import 'package:compiled_mirrors/equality.dart';
 
 import 'example.compiled_mirrors.dart';
 
-class Super1 {
-  int ham;
-}
-
-class Super2 {
-  int spam;
-}
-
 @compileMirror
-class Example extends Super1 {
+class Example {
   String foo;
   int bar;
 

--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -3,8 +3,16 @@ import 'package:compiled_mirrors/equality.dart';
 
 import 'example.compiled_mirrors.dart';
 
+class Super1 {
+  int ham;
+}
+
+class Super2 {
+  int spam;
+}
+
 @compileMirror
-class Example {
+class Example extends Super1 {
   String foo;
   int bar;
 

--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -1,7 +1,7 @@
 import 'package:compiled_mirrors/compiled_mirrors.dart';
 import 'package:compiled_mirrors/equality.dart';
 
-export 'example.compiled_mirrors.dart';
+import 'example.compiled_mirrors.dart';
 
 @compileMirror
 class Example {
@@ -9,10 +9,14 @@ class Example {
   int bar;
 
   @override
-  bool operator ==(Object other) => MirrorEquality.equals<Example>(
-      this, other, (c) => new Example$CompiledMirror(c));
+  bool operator ==(Object other) =>
+      MirrorEquality.equals(this, other, (c) => new Example$CompiledMirror(c));
 
   @override
   int get hashCode =>
-      MirrorEquality.hash<Example>(this, (c) => new Example$CompiledMirror(c));
+      MirrorEquality.hash(this, (c) => new Example$CompiledMirror(c));
+
+  @override
+  String toString() =>
+      MirrorEquality.asString(this, (c) => new Example$CompiledMirror(c));
 }

--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -1,9 +1,18 @@
 import 'package:compiled_mirrors/compiled_mirrors.dart';
+import 'package:compiled_mirrors/equality.dart';
 
 export 'example.compiled_mirrors.dart';
 
 @compileMirror
-class Eq1 {
+class Example {
   String foo;
   int bar;
+
+  @override
+  bool operator ==(Object other) => MirrorEquality.equals<Example>(
+      this, other, (c) => new Example$CompiledMirror(c));
+
+  @override
+  int get hashCode =>
+      MirrorEquality.hash<Example>(this, (c) => new Example$CompiledMirror(c));
 }

--- a/lib/compiled_mirrors.dart
+++ b/lib/compiled_mirrors.dart
@@ -1,5 +1,3 @@
-import 'package:quiver/core.dart';
-
 /// All classes annotated with this annotation will compile a mirror.
 const compileMirror = const CompileMirror._();
 
@@ -18,22 +16,6 @@ abstract class CompiledMirror<C> {
 
   /// Symbols for each field's name to an accessor for [instance]'s field value.
   Map<Symbol, FieldAccessor> get fields;
-
-  /// Checks that all fields of `this` and [other] are equal.
-  bool deepEquals(CompiledMirror<C> other) {
-    for (var symbol in fields.keys) {
-      if (fields[symbol]() != other.fields[symbol]()) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  /// Returns the hash of all the fields of [instance].
-  int get deepHash {
-    var fieldValues = fields.values.map((valueGetter) => valueGetter());
-    return hashObjects(fieldValues);
-  }
 
   String toDeepString() {
     var result = '${instance.runtimeType}(\n';

--- a/lib/compiled_mirrors.dart
+++ b/lib/compiled_mirrors.dart
@@ -17,5 +17,6 @@ abstract class CompiledMirror<C> {
   /// Symbols for each field's name to an accessor for [instance]'s field value.
   ///
   /// Describes all fields on [C] and all its superclasses *except* for Object.
+  /// This includes all mixins.
   Map<Symbol, FieldAccessor> get fields;
 }

--- a/lib/compiled_mirrors.dart
+++ b/lib/compiled_mirrors.dart
@@ -16,13 +16,4 @@ abstract class CompiledMirror<C> {
 
   /// Symbols for each field's name to an accessor for [instance]'s field value.
   Map<Symbol, FieldAccessor> get fields;
-
-  String toDeepString() {
-    var result = '${instance.runtimeType}(\n';
-    for (var symbol in fields.keys) {
-      result += '  $symbol: ${fields[symbol]()},\n';
-    }
-    result += ')';
-    return result;
-  }
 }

--- a/lib/compiled_mirrors.dart
+++ b/lib/compiled_mirrors.dart
@@ -15,5 +15,7 @@ abstract class CompiledMirror<C> {
   C get instance;
 
   /// Symbols for each field's name to an accessor for [instance]'s field value.
+  ///
+  /// Describes all fields on [C] and all its superclasses *except* for Object.
   Map<Symbol, FieldAccessor> get fields;
 }

--- a/lib/equality.dart
+++ b/lib/equality.dart
@@ -13,7 +13,7 @@ class MirrorEquality {
   /// @compileMirror
   /// class Foo {
   ///   @override
-  ///   bool operator==(Object other) => MirrorEquality.equals<Foo>(
+  ///   bool operator==(Object other) => MirrorEquality.equals(
   ///         this, other, (foo) => new Foo$CompiledMirror(foo));
   /// }
   static bool equals<T>(T self, other, CompiledMirror<T> mirror(T object)) {
@@ -40,7 +40,7 @@ class MirrorEquality {
   /// @compileMirror
   /// class Foo {
   ///   @override
-  ///   int get hashCode => MirrorEquality.hash<Foo>(
+  ///   int get hashCode => MirrorEquality.hash(
   ///         this, (foo) => new Foo$CompiledMirror(foo));
   /// }
   static int hash<T>(T self, CompiledMirror<T> mirror(T object)) {
@@ -57,7 +57,7 @@ class MirrorEquality {
   /// @compileMirror
   /// class Foo {
   ///   @override
-  ///   String toString => MirrorEquality.asString<Foo>(
+  ///   String toString => MirrorEquality.asString(
   ///         this, (foo) => new Foo$CompiledMirror(foo));
   /// }
   static String asString<T>(T self, CompiledMirror<T> mirror(T object)) {

--- a/lib/equality.dart
+++ b/lib/equality.dart
@@ -1,0 +1,33 @@
+import 'package:compiled_mirrors/compiled_mirrors.dart';
+
+/// Utility for generating object override methods.
+class MirrorEquality {
+  // This static class shouldn't be constructed.
+  MirrorEquality._();
+
+  /// Evaluates whether two reflections are equal.
+  ///
+  /// To use this as a class' equals operator, do the following:
+  ///
+  /// @compileMirror
+  /// class Foo {
+  ///   @override
+  ///   bool operator==(Object other) => MirrorEquality<Foo>.equals(
+  ///         this, other, (foo) => new Foo$CompiledMirror(foo));
+  /// }
+  static bool equals<T>(T self, other, CompiledMirror<T> mirror(T object)) {
+    if (other is T) {
+      var myMirror = mirror(self);
+      var otherMirror = mirror(other);
+      for (var symbol in myMirror.fields.keys) {
+        if (myMirror.fields[symbol]() != otherMirror.fields[symbol]()) {
+          return false;
+        }
+      }
+      // If all fields are equal, then the objects are equal.
+      return true;
+    }
+    // If the types are incompatible, then the objects are not equal.
+    return false;
+  }
+}

--- a/lib/equality.dart
+++ b/lib/equality.dart
@@ -1,4 +1,5 @@
 import 'package:compiled_mirrors/compiled_mirrors.dart';
+import 'package:quiver/core.dart';
 
 /// Utility for generating object override methods.
 class MirrorEquality {
@@ -29,5 +30,13 @@ class MirrorEquality {
     }
     // If the types are incompatible, then the objects are not equal.
     return false;
+  }
+
+  /// Returns the hash of all the fields of [instance].
+  static int hash<T>(T self, CompiledMirror<T> mirror(T object)) {
+    var mirrored = mirror(self);
+    var fieldValues =
+        mirrored.fields.values.map((valueGetter) => valueGetter());
+    return hashObjects(fieldValues);
   }
 }

--- a/lib/equality.dart
+++ b/lib/equality.dart
@@ -8,16 +8,17 @@ class MirrorEquality {
 
   /// Evaluates whether two reflections are equal.
   ///
-  /// To use this as a class' equals operator, do the following:
+  /// To use this as an operator==, do the following:
   ///
   /// @compileMirror
   /// class Foo {
   ///   @override
-  ///   bool operator==(Object other) => MirrorEquality<Foo>.equals(
+  ///   bool operator==(Object other) => MirrorEquality.equals<Foo>(
   ///         this, other, (foo) => new Foo$CompiledMirror(foo));
   /// }
   static bool equals<T>(T self, other, CompiledMirror<T> mirror(T object)) {
-    if (other is T) {
+    // If [other] is castable to [T] then we will test its fields for equality.
+    if (other as T != null) {
       var myMirror = mirror(self);
       var otherMirror = mirror(other);
       for (var symbol in myMirror.fields.keys) {
@@ -33,10 +34,39 @@ class MirrorEquality {
   }
 
   /// Returns the hash of all the fields of [instance].
+  ///
+  /// To use this as a hashCode getter, do the following:
+  ///
+  /// @compileMirror
+  /// class Foo {
+  ///   @override
+  ///   int get hashCode => MirrorEquality.hash<Foo>(
+  ///         this, (foo) => new Foo$CompiledMirror(foo));
+  /// }
   static int hash<T>(T self, CompiledMirror<T> mirror(T object)) {
-    var mirrored = mirror(self);
-    var fieldValues =
-        mirrored.fields.values.map((valueGetter) => valueGetter());
+    var fields = mirror(self).fields;
+    var fieldValues = fields.values.map((valueGetter) => valueGetter());
     return hashObjects(fieldValues);
+  }
+
+  /// Represents a [T] as a String describing all of its fields.
+  ///
+  /// This is useful for debugging in tests. To use it as a toString method,
+  /// do the following:
+  ///
+  /// @compileMirror
+  /// class Foo {
+  ///   @override
+  ///   String toString => MirrorEquality.asString<Foo>(
+  ///         this, (foo) => new Foo$CompiledMirror(foo));
+  /// }
+  static String asString<T>(T self, CompiledMirror<T> mirror(T object)) {
+    var fields = mirror(self).fields;
+    var result = '${self.runtimeType}(\n';
+    for (var symbol in fields.keys) {
+      result += '  $symbol: ${fields[symbol]()},\n';
+    }
+    result += ')';
+    return result;
   }
 }

--- a/lib/src/transformer/generator.dart
+++ b/lib/src/transformer/generator.dart
@@ -23,7 +23,7 @@ class DescriptionGenerator {
     }
     // By definition of [CompiledMirrors], we exclude the Object fields.
     var objectFields =
-        new Set<Element>.from(supertype.accessors.map((f) => f.name));
+        new Set<String>.from(supertype.accessors.map((f) => f.name));
     fields.removeWhere((element) => objectFields.contains(element.name));
     return fields;
   }

--- a/lib/src/transformer/generator.dart
+++ b/lib/src/transformer/generator.dart
@@ -14,7 +14,19 @@ class DescriptionGenerator {
   DescriptionGenerator(this.classElement);
 
   String get _className => classElement.name;
-  Iterable<Element> get _classFields => classElement.fields;
+  Iterable<Element> get _classFields {
+    var fields = new Set<Element>.from(classElement.fields);
+    var supertype = classElement.supertype;
+    while (!supertype.isObject) {
+      fields.addAll(supertype.accessors);
+      supertype = classElement.supertype;
+    }
+    // By definition of [CompiledMirrors], we exclude the Object fields.
+    var objectFields =
+        new Set<Element>.from(supertype.accessors.map((f) => f.name));
+    fields.removeWhere((element) => objectFields.contains(element.name));
+    return fields;
+  }
 
   String get _generatedClassName => '$_className\$CompiledMirror';
 

--- a/lib/src/transformer/generator.dart
+++ b/lib/src/transformer/generator.dart
@@ -15,17 +15,30 @@ class DescriptionGenerator {
 
   String get _className => classElement.name;
   Iterable<Element> get _classFields {
-    var fields = new Set<Element>.from(classElement.fields);
+    Map<String, Element> fromIterable(Iterable<Element> elements) {
+      return new Map.fromIterables(elements.map((e) => e.name), elements);
+    }
+
+    var fields = fromIterable(classElement.fields);
+    for (var mixin in classElement.mixins) {
+      fields.addAll(fromIterable(mixin.accessors.where((a) => a.isGetter)));
+    }
     var supertype = classElement.supertype;
     while (!supertype.isObject) {
-      fields.addAll(supertype.accessors);
-      supertype = classElement.supertype;
+      fields.addAll(fromIterable(supertype.accessors.where((a) => a.isGetter)));
+      for (var mixin in supertype.mixins) {
+        fields.addAll(fromIterable(mixin.accessors.where((a) => a.isGetter)));
+      }
+      supertype = supertype.superclass;
     }
     // By definition of [CompiledMirrors], we exclude the Object fields.
     var objectFields =
         new Set<String>.from(supertype.accessors.map((f) => f.name));
-    fields.removeWhere((element) => objectFields.contains(element.name));
-    return fields;
+    for (var fieldName in objectFields) {
+      fields.remove(fieldName);
+    }
+    var sortedKeys = fields.keys.toList()..sort();
+    return sortedKeys.map((key) => fields[key]);
   }
 
   String get _generatedClassName => '$_className\$CompiledMirror';

--- a/test/transformer_test.dart
+++ b/test/transformer_test.dart
@@ -29,6 +29,10 @@ main() {
     test('with multiple classes', () async {
       await testBuilderWithAssets(builder, [_multiClassLibrary]);
     });
+
+    test('with subclasses, superclasses, and mixins', () async {
+      await testBuilderWithAssets(builder, [_extendedClassLibrary]);
+    });
   });
 
   group('Builder generates with several libraries', () {
@@ -80,8 +84,8 @@ class OneClass$CompiledMirror extends CompiledMirror<OneClass> {
   OneClass$CompiledMirror(OneClass instance):
     this.instance = instance,
     this.fields = {
-      #foo: () => instance.foo,
       #bar: () => instance.bar,
+      #foo: () => instance.foo,
     };
 
 }
@@ -122,12 +126,12 @@ class VariedDeclarations$CompiledMirror extends CompiledMirror<VariedDeclaration
   VariedDeclarations$CompiledMirror(VariedDeclarations instance):
     this.instance = instance,
     this.fields = {
-      #constantField: () => instance.constantField,
-      #foo: () => instance.foo,
+      #_bup: () => instance._bup,
       #bar: () => instance.bar,
       #baz: () => instance.baz,
       #bop: () => instance.bop,
-      #_bup: () => instance._bup,
+      #constantField: () => instance.constantField,
+      #foo: () => instance.foo,
     };
 
 }
@@ -292,6 +296,101 @@ class ClassFour$CompiledMirror extends CompiledMirror<ClassFour> {
   ClassFour$CompiledMirror(ClassFour instance):
     this.instance = instance,
     this.fields = {
+    };
+
+}
+''',
+  ),
+);
+
+const TestAsset _extendedClassLibrary = const TestAsset(
+  const SourceAsset(
+    'test_builder|lib/extended_class.dart',
+    r'''
+import 'package:compiled_mirrors/compiled_mirrors.dart';
+
+@compileMirror
+class BaseClass {
+  String foo;
+  int bar;
+}
+
+@compileMirror
+class ExtendedClass extends BaseClass {
+  @override
+  String get foo => 5;
+
+  @override
+  set foo(String newValue) {}
+
+  final var baz;
+}
+
+class Mixin {
+  int ham;
+  int spam;
+}
+
+@compileMirror
+class ExtendedClassWithMixin extends BaseClass with Mixin {
+  bool eggs = false;
+}
+''',
+  ),
+  const SourceAsset(
+    'test_builder|lib/extended_class.compiled_mirrors.dart',
+    r'''
+import 'package:compiled_mirrors/compiled_mirrors.dart';
+import 'extended_class.dart';
+
+class BaseClass$CompiledMirror extends CompiledMirror<BaseClass> {
+  @override
+  final BaseClass instance;
+
+  @override
+  final Map<Symbol, FieldAccessor> fields;
+
+  BaseClass$CompiledMirror(BaseClass instance):
+    this.instance = instance,
+    this.fields = {
+      #bar: () => instance.bar,
+      #foo: () => instance.foo,
+    };
+
+}
+
+class ExtendedClass$CompiledMirror extends CompiledMirror<ExtendedClass> {
+  @override
+  final ExtendedClass instance;
+
+  @override
+  final Map<Symbol, FieldAccessor> fields;
+
+  ExtendedClass$CompiledMirror(ExtendedClass instance):
+    this.instance = instance,
+    this.fields = {
+      #bar: () => instance.bar,
+      #baz: () => instance.baz,
+      #foo: () => instance.foo,
+    };
+
+}
+
+class ExtendedClassWithMixin$CompiledMirror extends CompiledMirror<ExtendedClassWithMixin> {
+  @override
+  final ExtendedClassWithMixin instance;
+
+  @override
+  final Map<Symbol, FieldAccessor> fields;
+
+  ExtendedClassWithMixin$CompiledMirror(ExtendedClassWithMixin instance):
+    this.instance = instance,
+    this.fields = {
+      #bar: () => instance.bar,
+      #eggs: () => instance.eggs,
+      #foo: () => instance.foo,
+      #ham: () => instance.ham,
+      #spam: () => instance.spam,
     };
 
 }


### PR DESCRIPTION
Generate the fields of all parent classes and mixins on an object.

Move the equality, hashCode and toString methods out of CompiledMirror into a utility class so that it's clear what is part of the mirror and what is built for convenience.

Enable strong mode.

Fixes #3 